### PR TITLE
Add definition for MC6809 disassembler in r2-extras PR #57

### DIFF
--- a/db/mc6809
+++ b/db/mc6809
@@ -1,0 +1,20 @@
+R2PM_BEGIN
+
+R2PM_GIT "https://github.com/radare/radare2-extras"
+R2PM_DESC "[r2-asm] Motorola MC6809 disassembler"
+
+R2PM_INSTALL() {
+	./configure --prefix="${R2PM_PREFIX} || exit 1
+	cd libr/asm/p
+	${MAKE} clean
+	ls
+	${MAKE} asm_mc6809.${LIBEXT} || exit 1
+	cp -f asm_mc6809.${LIBEXT} "${R2PM_PLUGDIR}" || exit 1
+	echo "cp -f asm_mc6809.${LIBEXT} ${R2PM_PLUGDIR}"
+}
+
+R2PM_UNINSTALL() {
+	rm -f "${R2PM_PLUGDIR}/asm_mc6809".*
+}
+
+R2PM_END


### PR DESCRIPTION
https://github.com/radare/radare2-extras/pull/57

Visually checked against existing definitions.