### PR TITLE
remove check for libelf and zlib for travis build

### DIFF
--- a/db/libdwarf
+++ b/db/libdwarf
@@ -4,9 +4,9 @@ R2PM_GIT "git://git.code.sf.net/p/libdwarf/code" libdwarf-code
 R2PM_DESC "libdwarf - git"
 
 R2PM_INSTALL() {
-	if ! $(pkg-config --exists libelf) || ! $(pkg-config --exists zlib); then
-		echo "ERROR: Libraries required: libelf and zlib"; exit 1
-	fi
+#	if ! $(pkg-config --exists libelf) || ! $(pkg-config --exists zlib); then
+#		echo "ERROR: Libraries required: libelf and zlib"; exit 1
+#	fi
 	./configure --prefix="${R2PM_PREFIX}"
 	${MAKE}
 }


### PR DESCRIPTION
On ubuntu12.04, `pkg-config` is not working for `libelf-dev` hence travis for `r2pm -i dwarf-parser` is failing. Hopefully this should fix that issue.