### PR TITLE
Fix capitalization of "Lua" in package descriptions

### DIFF
--- a/db/r2-lua53
+++ b/db/r2-lua53
@@ -1,7 +1,7 @@
 R2PM_BEGIN
 
 R2PM_GIT "https://github.com/radare/radare2-extras"
-R2PM_DESC "lua53 disassembler, analyzer and bin parser plugins for radare2"
+R2PM_DESC "Lua 5.3 disassembler, analyzer and bin parser plugins for radare2"
 
 R2PM_INSTALL() {
 	cd lua53 || R2PM_FAIL "Cd"

--- a/db/r2api-lua
+++ b/db/r2api-lua
@@ -1,7 +1,7 @@
 R2PM_BEGIN
 
 R2PM_GIT "https://github.com/radare/radare2-bindings"
-R2PM_DESC "[r2-script] Native LUA API bindings"
+R2PM_DESC "[r2-script] Native Lua API bindings"
 
 R2PM_INSTALL() {
 	./configure --prefix="${R2PM_PREFIX}" --enable=lua || exit 1

--- a/db/r2b-lua
+++ b/db/r2b-lua
@@ -1,7 +1,7 @@
 R2PM_BEGIN
 
 R2PM_GIT "https://github.com/radare/radare2-bindings"
-R2PM_DESC "[syspkg] lua native swig bindings"
+R2PM_DESC "[syspkg] Native Lua SWIG bindings"
 # R2PM_DEPS valabind lua-lib
 
 R2PM_INSTALL() {


### PR DESCRIPTION
According to the Lua website,[1] only the first letter of "Lua"
should be capitalized, so do the same in the package descriptions
here. Also, while we're at it, fix the capitalization of SWIG and
tweak the word order too.

[1] https://www.lua.org/about.html