### PR TITLE
Fix broken quote in mc6809 install script

### DIFF
--- a/db/mc6809
+++ b/db/mc6809
@@ -4,7 +4,7 @@ R2PM_GIT "https://github.com/radare/radare2-extras"
 R2PM_DESC "[r2-arch] Motorola MC6809 disassembler"
 
 R2PM_INSTALL() {
-	./configure --prefix="${R2PM_PREFIX} || exit 1
+	./configure --prefix="${R2PM_PREFIX}" || exit 1
 	cd libr/asm/p
 	${MAKE} clean
 	ls


### PR DESCRIPTION
I needed to do this to stop "r2pm install mc6809" giving me this:

/home/daniel/.config/radare2/r2pm/db/mc6809: line 17: unexpected EOF while looking for matching `"'
/home/daniel/.config/radare2/r2pm/db/mc6809: line 21: syntax error: unexpected end of file
/usr/bin/r2pm: line 389: R2PM_INSTALL: command not found
