### PR TITLE
Fix retdec installation

### DIFF
--- a/db/retdec
+++ b/db/retdec
@@ -8,9 +8,9 @@ RETDEC_LINUX=${RETDEC_URLBASE}/v${RETDEC_VERSION}/retdec-v${RETDEC_VERSION}-ubun
 R2PM_GIT "https://github.com/securisec/r2retdec"
 R2PM_DESC "[retdec] Official Nightly binary build of the retdec decompiler"
 if [ "`uname`" = Darwin ]; then
-	R2PM_TGZ "${RETDEC_MACOS}" "retdec"
+	R2PM_TGZ "${RETDEC_MACOS}" "/retdec"
 else
-	R2PM_TGZ "${RETDEC_LINUX}" "retdec"
+	R2PM_TGZ "${RETDEC_LINUX}" "/retdec"
 fi
 
 R2PM_INSTALL() {


### PR DESCRIPTION
With radare/radare2#15033, fix retdec installation by changing install dir from e.g `retdec/retdec/bin` to `retdec/bin`.